### PR TITLE
Fixing RsBanano's node handle to make it work, readme update, default ports update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RsBanano is a fork of RsNano, which is a Rust port of the original Nano node.
 
     docker build -f scripts/docker/node/Dockerfile -t rsbanano-node https://github.com/stjet/rsbanano-node.git#develop
 
-    docker run -p 54000:54000 -v ~/BananoBeta:/root/BananoBeta rsbanano-node:latest node run --network=beta
+    docker run -p 54019:54019 -v ~/BananoBeta:/root/BananoBeta rsbanano-node:latest node run --network=beta
 
 ## Option 3: Build from source
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ RsBanano is a fork of RsNano, which is a Rust port of the original Nano node.
 
 ## Option 2: Build your own Docker image
 
-    docker build -f scripts/docker/node/Dockerfile -t rsbanano-node https://github.com/stjet/rsbanano-node.git#develop
+    docker build -f scripts/docker/node/Dockerfile -t rsbanano-node https://github.com/stjet/rsban-node.git#develop
 
-    docker run -p 54019:54019 -v ~/BananoBeta:/root/BananoBeta rsbanano-node:latest node run --network=beta
+    docker run -p 54019:54019 -v ~/BananoBeta:/root/BananoBeta rsban-node:latest node run --network=beta
 
 ## Option 3: Build from source
 
@@ -36,16 +36,16 @@ Currently you can only build RsBanano on Linux and on Mac.
 To just build and run the rsbanano_node:
 
     git clone https://github.com/stjet/rsbanano-node.git
-    cd rsbanano-node/main
+    cd rsban-node/main
     cargo build --release
     cargo run --release -- node run --network=beta
 
 To install and run the rsbanano_node executable:
 
     git clone https://github.com/stjet/rsbanano-node.git
-    cd rsbanano-node
+    cd rsban-node
     cargo install --path main
-    rsbanano_node node run --network=beta
+    rsban_node node run --network=beta
 
 ### Contact us
 

--- a/node/src/config/network_constants.rs
+++ b/node/src/config/network_constants.rs
@@ -91,10 +91,11 @@ impl NetworkConstants {
             protocol_version_min: protocol_info.version_min,
             bootstrap_protocol_version_min: BootstrapAscendingConfig::default()
                 .min_protocol_version,
-            default_node_port: 7075,
-            default_rpc_port: 7076,
-            default_ipc_port: 7077,
-            default_websocket_port: 7078,
+            /// https://github.com/BananoCoin/banano/wiki/Network-Specifications#default-ports
+            default_node_port: 7071,
+            default_rpc_port: 7072,
+            default_ipc_port: 7073,
+            default_websocket_port: 7074,
             aec_loop_interval: Duration::from_millis(300),
             cleanup_period,
             keepalive_period: Duration::from_secs(15),

--- a/scripts/docker/ci/Dockerfile-base
+++ b/scripts/docker/ci/Dockerfile-base
@@ -27,5 +27,5 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
     && cmake --build build --config Release \
     && cmake --install build --config Release 
 
-ARG REPOSITORY=stjet/rsbanano-node
+ARG REPOSITORY=banano/rsban-node
 LABEL org.opencontainers.image.source=https://github.com/$REPOSITORY

--- a/scripts/docker/ci/Dockerfile-base
+++ b/scripts/docker/ci/Dockerfile-base
@@ -27,5 +27,5 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
     && cmake --build build --config Release \
     && cmake --install build --config Release 
 
-ARG REPOSITORY=simpago/rsnano-node
+ARG REPOSITORY=stjet/rsbanano-node
 LABEL org.opencontainers.image.source https://github.com/$REPOSITORY

--- a/scripts/docker/ci/Dockerfile-base
+++ b/scripts/docker/ci/Dockerfile-base
@@ -28,4 +28,4 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
     && cmake --install build --config Release 
 
 ARG REPOSITORY=stjet/rsbanano-node
-LABEL org.opencontainers.image.source https://github.com/$REPOSITORY
+LABEL org.opencontainers.image.source=https://github.com/$REPOSITORY

--- a/scripts/docker/node/Dockerfile
+++ b/scripts/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS builder
 
 ARG COMPILER=gcc
 ARG NANO_NETWORK=live

--- a/scripts/docker/node/Dockerfile
+++ b/scripts/docker/node/Dockerfile
@@ -43,5 +43,5 @@ ENV PATH="${PATH}:/usr/bin"
 ENTRYPOINT ["/usr/bin/rsban_node"]
 CMD ["node", "run"]
 
-ARG REPOSITORY=banano/rsbanano-node
+ARG REPOSITORY=banano/rsban-node
 LABEL org.opencontainers.image.source https://github.com/$REPOSITORY

--- a/scripts/docker/node/Dockerfile
+++ b/scripts/docker/node/Dockerfile
@@ -30,7 +30,7 @@ FROM ubuntu:22.04
 RUN groupadd --gid 1000 bananode && \
     useradd --uid 1000 --gid bananode --shell /bin/bash --create-home bananode
 
-COPY --from=builder /tmp/src/target/release/rsbanano_node /usr/bin
+COPY --from=builder /tmp/src/target/release/rsban_node /usr/bin
 COPY --from=builder /etc/banano-network /etc
 
 COPY scripts/docker/node/config /usr/share/banano/config
@@ -40,7 +40,7 @@ WORKDIR /root
 USER root
 
 ENV PATH="${PATH}:/usr/bin"
-ENTRYPOINT ["/usr/bin/rsbanano_node"]
+ENTRYPOINT ["/usr/bin/rsban_node"]
 CMD ["node", "run"]
 
 ARG REPOSITORY=banano/rsbanano-node

--- a/scripts/docker/node/Dockerfile
+++ b/scripts/docker/node/Dockerfile
@@ -44,4 +44,4 @@ ENTRYPOINT ["/usr/bin/rsban_node"]
 CMD ["node", "run"]
 
 ARG REPOSITORY=banano/rsban-node
-LABEL org.opencontainers.image.source https://github.com/$REPOSITORY
+LABEL org.opencontainers.image.source=https://github.com/$REPOSITORY


### PR DESCRIPTION
In this PR, rsbanano-node is either `rsban_node` or `rsban-node`, depending on the case. 
Update readme.
Update default ports.